### PR TITLE
Separated out the fastq creation from alignment.

### DIFF
--- a/vcomp/bam_simulation.py
+++ b/vcomp/bam_simulation.py
@@ -78,8 +78,7 @@ def create_bam(ref_genome, reads1, reads2, bwapath, samtoolspath):
     subprocess.check_call(script_path, shell=True)
     return dest
 
-def gen_alt_bam(ref_path, variants, conf, homs=True, depth=250):
-
+def gen_alt_fq(ref_path, variants, homs=True, depth=250):
     reads1 = "input_r1.fq"
     reads2 = "input_r2.fq"
     read1_fh = open(reads1, "w")
@@ -96,6 +95,10 @@ def gen_alt_bam(ref_path, variants, conf, homs=True, depth=250):
 
     read1_fh.close()
     read2_fh.close()
+    return (reads1, reads2)
+
+def gen_alt_bam(ref_path, conf, reads):
+    reads1, reads2 = reads
     bam = create_bam(ref_path, reads1, reads2, conf.get('main', 'bwa_path'), conf.get('main', 'samtools_path'))
     verify_reads(reads1, reads2, bam, conf)
     return bam

--- a/vcomp/injectvar.py
+++ b/vcomp/injectvar.py
@@ -121,7 +121,8 @@ def process_variant(variant, conf, homs, keep_tmpdir=False):
         ref_path = conf.get('main', 'ref_genome')
 
         bed = callers.vars_to_bed([variant])
-        bam = bam_simulation.gen_alt_bam(ref_path, [variant], conf, homs)
+        reads = bam_simulation.gen_alt_fq(ref_path, [variant], homs=True, depth=250)
+        bam = bam_simulation.gen_alt_bam(ref_path, conf, reads)
 
         var_results = {}
         variant_callers = callers.get_callers()

--- a/vcomp/sb_vcomp/__init__.py
+++ b/vcomp/sb_vcomp/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'goran'


### PR DESCRIPTION
Separated out the fastq creation from alignment. This way it should be easier to port the pipeline to CWL/SBSDK if there proves to be a need.
